### PR TITLE
Add java file's extension

### DIFF
--- a/plugin/autotags.vim
+++ b/plugin/autotags.vim
@@ -179,7 +179,7 @@ fun! s:AutotagsInit()
     endif
 
     if !exists("g:autotags_cscope_file_extensions")
-        let g:autotags_cscope_file_extensions = ".cpp .cc .cxx .m .hpp .hh .h .hxx .c .idl"
+        let g:autotags_cscope_file_extensions = ".cpp .cc .cxx .m .hpp .hh .h .hxx .c .idl .java"
     endif
 
     let s:cscope_file_pattern = '.*\' .


### PR DESCRIPTION
Java can also be parsed through ctags and cscope so you may had the ".java" extension to the default file's extension.
