### PR TITLE
Make Find BSD Friendly

### DIFF
--- a/plugin/autotags.vim
+++ b/plugin/autotags.vim
@@ -328,7 +328,7 @@ fun! s:AutotagsGenerate(sourcedir, tagsdir)
         \ " nice -15 find " . shellescape(a:sourcedir) .
         \ " -not -regex '.*\\.git.*' " .
         \ " -regex '" . s:cscope_file_pattern . "' " .
-        \ " -fprint cscope.files")
+        \ " -exec sh -c 'printf %s\\\\n \"$@\" > cscope.files' _ {} +")
     if getfsize(l:cscopedir . "/cscope.files") > 0
         echomsg system("cd " . shellescape(l:cscopedir) . " && " .
             \ "nice -15 " . g:autotags_cscope_exe . " -b -q")


### PR DESCRIPTION
The `find` command being used to generate the cscope file is GNU only, so it won't work OOTB on OS X, or various other BSD flavors.
